### PR TITLE
Remove -rdynamic to allow building on Mac

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,7 @@ all: default java
 java: $(JAVA_JAR) $(JAVA_LIB)
 
 $(LIB): ssw.c ssw.h
-	$(CC) $(CFLAGS) -fPIC -shared -rdynamic -o $@ $<
+	$(CC) $(CFLAGS) -fPIC -shared -o $@ $<
 
 $(PROG): main.c kseq.h
 
@@ -35,7 +35,7 @@ $(EXAMPLE_CPP): example.cpp $(LOBJS) $(LCPPOBJS)
 	$(CXX) -o $@ $^ $(CXXFLAGS) -lm -lz
 
 $(JAVA_LIB): sswjni.c ssw.c ssw.h
-	$(CC) $(CFLAGS) $(JAVA_INLCUDES) -fPIC -shared -rdynamic -o $@ $< ssw.c 
+	$(CC) $(CFLAGS) $(JAVA_INLCUDES) -fPIC -shared -o $@ $< ssw.c 
 
 $(JAVA_JAR): $(JAVA_OBJ)
 	jar cvfe $@ ssw.Example $^


### PR DESCRIPTION
I'm just going to pull this right in, so I can test a VG pr that uses it.
