### PR TITLE
Don't warn on every small alignment through the C++ API

### DIFF
--- a/src/ssw.c
+++ b/src/ssw.c
@@ -795,9 +795,6 @@ s_align* ssw_align (const s_profile* prof,
 	r->read_begin1 = -1;
 	r->cigar = 0;
 	r->cigarLen = 0;
-	if (maskLen < 15) {
-		fprintf(stderr, "When maskLen < 15, the function ssw_align doesn't return 2nd best alignment information.\n");
-	}
 
 	// Find the alignment scores and ending positions
 	if (prof->profile_byte) {


### PR DESCRIPTION
Without this, the unit tests I am developing for bluntification are ugly because random messages go to stderr about my small overlaps.